### PR TITLE
Set `checkpoint_state_trie_root` to previous block's `state_root`

### DIFF
--- a/leader/src/lib.rs
+++ b/leader/src/lib.rs
@@ -397,7 +397,7 @@ pub async fn gather_witness(tx: TxHash, provider: &Provider<Http>) -> Result<Vec
             },
             gas_used_before: gas_used,
             gas_used_after: gas_used + receipt.gas_used.unwrap(),
-            checkpoint_state_trie_root: H256::zero(),
+            checkpoint_state_trie_root: prev_block.state_root, // TODO: make it configurable
             trie_roots_after,
             txn_number_before: receipt.transaction_index.0[0].into(),
         };


### PR DESCRIPTION
We currently pass a dummy `H256::zero()` for the checkpoint state root, causing mismatch when reaching the final block proof layer.
This sets the checkpoint to always be the previous block, so that each block can be proven as standalone without passing a proof.